### PR TITLE
Feature/airflow

### DIFF
--- a/local/airflow/dags/dagme/dagme.py
+++ b/local/airflow/dags/dagme/dagme.py
@@ -1,6 +1,7 @@
 #Adapted from: https://airflow.apache.org/docs/apache-airflow/stable/howto/operator/python.html
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
 import time
 from datetime import datetime
@@ -16,8 +17,23 @@ def my_sleeping_function(random_base):
 with DAG(dag_id='dagme', schedule_interval='* * * * *', default_args=default_args, catchup=False) as dag:
     
     run_this = PythonOperator(
-        task_id='sleep_parent',
+        task_id='sleep',
         python_callable=my_sleeping_function,
         op_kwargs={'random_base': float(1) / 10},
         dag=dag,
+    )
+
+    sleep_more_task = KubernetesPodOperator(
+        name="sleep_more",
+        task_id="sleep_more",
+        namespace="airflow",
+        labels={
+            "app": "sleep-more"
+        },
+        image="ubuntu:20.04",
+        cmds=["sleep"],
+        arguments=["5"],
+        get_logs=True,
+        hostnetwork=False,
+        in_cluster=True
     )

--- a/qa/airflow/access.yml
+++ b/qa/airflow/access.yml
@@ -1,0 +1,45 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: airflow
+  namespace: spark
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - "create"
+      - "get"
+      - "delete"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/log"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/exec"
+    verbs:
+      - "create"
+      - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: airflow
+  namespace: spark
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: airflow
+subjects:
+  - kind: ServiceAccount
+    name: airflow
+    namespace: airflow

--- a/qa/airflow/configsmap-override.yml
+++ b/qa/airflow/configsmap-override.yml
@@ -22,7 +22,7 @@ data:
       labels:
         app: airflow-worker
     spec:
-      serviceAccountName: default
+      serviceAccountName: airflow
       volumes:
         - emptyDir: {}
           name: airflow-logs

--- a/qa/airflow/kustomization.yaml
+++ b/qa/airflow/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../cqdg-orchestrations/airflow
   - ingress.yml
+  - access.yml
 
 patchesStrategicMerge:
   - deployments-override.yml


### PR DESCRIPTION
- Added kubernetes pod operator example in local airflow environment
- Fixed template service account so that kubernetes pod operator can properly launch pods
- Gave kubernetes pod operator spark namespace access to launch spark jobs 