### PR TITLE
fix: #257 Ensure that the kubernetes executor pods in the local envir…

### DIFF
--- a/local/airflow/configsmap-override.yml.tpl
+++ b/local/airflow/configsmap-override.yml.tpl
@@ -29,7 +29,7 @@ data:
       labels:
         app: airflow-worker
     spec:
-      serviceAccountName: default
+      serviceAccountName: airflow
       volumes:
         - emptyDir: {}
           name: airflow-logs


### PR DESCRIPTION
…onment are set to the right service group, otherwise the kubernetes pod operator won't be able to launch pod