### PR TITLE
fix: #298 Fixed wrong namespace in keycloak restore job

### DIFF
--- a/qa/keycloak/backups/restores/kustomization.yaml
+++ b/qa/keycloak/backups/restores/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: airflow
-
 resources:
   - postgres-qa-server-db-transfer.yml


### PR DESCRIPTION
Fixed wrong namespace in keycloak restore job